### PR TITLE
docs(📝): fix cdn url typo for nent.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Each component you use is lazy-loaded when you first use one. Most are tiny, wit
 <head>
   <script
     type="module"
-    src="https://cdn.jsdelivr.net/npm/@nent/core/dist/esm/nent.jss"
+    src="https://cdn.jsdelivr.net/npm/@nent/core/dist/esm/nent.js"
   ></script>
 </head>
 ```


### PR DESCRIPTION
Hello just saw a tiny issue related to cdn while trying this out. There is an extra `s` in the cdn url which makes it invalid. This PR fixes it.

<a href="https://gitpod.io/#https://github.com/nent/nent/pull/276"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

