### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/tools/docs/src/pages/routing/dynamic/child.html
+++ b/tools/docs/src/pages/routing/dynamic/child.html
@@ -2,7 +2,7 @@
   <h1> Route-based Content </h1>
   <p class="lead">This page uses route and URL data within the content!</p>
   <img style="width: 100%; min-height: 200px;"
-    src="https://source.unsplash.com/random/500x200?{{route:item}}" />
+    src="https://picsum.photos/seed/{{route:item}}/500/200" />
   <h2>Learn About '{{route:item}}'</h2>
   <p>{{storage:name}}, you picked a good one!
   <h2>Under the Hood</h2>


### PR DESCRIPTION
`tools/docs/src/pages/routing/dynamic/child.html` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and the endpoint now returns 503 errors. Browser screenshots typically render a broken image icon instead of the intended placeholder.

You can verify in any browser:

```
curl -I https://source.unsplash.com/random/800x600?office
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Updates the dynamic-routing docs example so the demo image renders again instead of 503-ing.

#### Replacement details

Picsum's `seed/<value>` pattern gives a stable, deterministic image per `{{route:item}}` value, which keeps the docs demo's intent (show a different image per route param). Same dimensions.

#### Background

I'm tracking deprecated image-CDN URLs across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built to make it easy to drop real Unsplash photos into projects without registering an Unsplash app or managing API keys. tteg isn't a dependency of this PR — the fix above is dependency-free. But if you ever want to swap the static replacement for something topic-aware, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

A 16k-files-across-885-repos summary of the deprecation is at [`kiluazen/tteg/RESEARCH.md`](https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md).
